### PR TITLE
option --use-concolic-taint=true:no addConstraint

### DIFF
--- a/klee/include/klee/Executor.h
+++ b/klee/include/klee/Executor.h
@@ -112,6 +112,7 @@ protected:
   std::vector<TimerInfo*> timers;
   PTree *processTree;
   bool concolicMode;
+  bool concolicTaint;
 
   /// Used to track states that have been added during the current
   /// instructions step.

--- a/klee/lib/Core/Executor.cpp
+++ b/klee/lib/Core/Executor.cpp
@@ -354,6 +354,7 @@ Executor::Executor(const InterpreterOptions &opts,
     specialFunctionHandler(0),
     processTree(0),
     concolicMode(false),
+    concolicTaint(false),
     replayOut(0),
     replayPath(0),    
     usingSeeds(0),
@@ -812,12 +813,14 @@ Executor::concolicFork(ExecutionState &current, ref<Expr> condition, bool isInte
 
     if (current.forkDisabled) {
        if (ce->isTrue()) {
-           //Condition is true in the current state
-           addConstraint(current, condition);
+           if(!concolicTaint)
+              //Condition is true in the current state
+              addConstraint(current, condition);
            return StatePair(&current, 0);
        } else {
-           //Condition is false in the current state
-           addConstraint(current, Expr::createIsZero(condition));
+           if(!concolicTaint)
+              //Condition is false in the current state
+              addConstraint(current, Expr::createIsZero(condition));
            return StatePair(0, &current);
        }
     }

--- a/qemu/s2e/S2EExecutor.cpp
+++ b/qemu/s2e/S2EExecutor.cpp
@@ -239,6 +239,11 @@ cl::opt<bool>
 ConcolicMode("use-concolic-execution",
                cl::desc("Concolic execution mode"),  cl::init(true));
 
+// Disable fork and use make_concolic to use Concolic Taint
+cl::opt<bool>
+ConcolicTaint("use-concolic-taint",
+               cl::desc("Single Concolic Taint"),  cl::init(false));
+
 cl::opt<bool>
 DebugConstraints("debug-constraints",
                cl::desc("Check that added constraints are satisfiable"),  cl::init(false));
@@ -856,6 +861,7 @@ S2EExecutor::S2EExecutor(S2E* s2e, TCGLLVMContext *tcgLLVMContext,
     g_s2e_concretize_io_writes = ConcretizeIoWrites;
 
     concolicMode = ConcolicMode;
+    concolicTaint = ConcolicTaint;
 
     if (UseFastHelpers) {
         if (!ForkOnSymbolicAddress) {


### PR DESCRIPTION
Trun --use-concolic-taint on to not addConstraint while using single path concolic execution to speed up
